### PR TITLE
Routing ApplicationStore handleNavigate emit change

### DIFF
--- a/routing/stores/ApplicationStore.js
+++ b/routing/stores/ApplicationStore.js
@@ -30,7 +30,7 @@ var ApplicationStore = createStore({
         this.currentPageName = pageName;
         this.currentPage = page;
         this.currentRoute = route;
-        this.emit('change');
+        this.emitChange();
     },
     updatePageTitle: function (title) {
         this.pageTitle = title.pageTitle;


### PR DESCRIPTION
In the routing example, the ApplicationStore.js was calling .emit('change') inside the handleNavigate function. This wasn't properly emiting the change, so this has been changed to .emitChange()
